### PR TITLE
luci-app-advanced-reboot: add MX4200 v1 and v2 to README.md

### DIFF
--- a/luci-app-advanced-reboot/README.md
+++ b/luci-app-advanced-reboot/README.md
@@ -23,6 +23,8 @@ Currently supported dual-firmware devices include:
 -   Linksys EA8300
 -   Linksys EA8500
 -   Linksys MR8300
+-   Linksys MX4200v1
+-   Linksys MX4200v2
 -   Linksys WHW01 v1
 -   Linksys WHW03 v2
 -   Linksys WRT32X


### PR DESCRIPTION
Include MX4200v1 and MX4200v2 in the list of supported devices