### PR TITLE
Updated pbr reload command for hotplug script

### DIFF
--- a/pbr/1.1.8/README.md
+++ b/pbr/1.1.8/README.md
@@ -921,7 +921,7 @@ mkdir -p /etc/hotplug.d/iface/
 cat << 'EOF' > /etc/hotplug.d/iface/70-pbr
 !/bin/sh
 logger -t pbr "Reloading $INTERFACE due to $ACTION of $INTERFACE ($DEVICE)"
-/etc/init.d/pbr reload_interface "$INTERFACE"
+/etc/init.d/pbr on_interface_reload "$INTERFACE"
 EOF
 ```
 

--- a/pbr/README.md
+++ b/pbr/README.md
@@ -921,7 +921,7 @@ mkdir -p /etc/hotplug.d/iface/
 cat << 'EOF' > /etc/hotplug.d/iface/70-pbr
 !/bin/sh
 logger -t pbr "Reloading $INTERFACE due to $ACTION of $INTERFACE ($DEVICE)"
-/etc/init.d/pbr reload interface "$INTERFACE"
+/etc/init.d/pbr on_interface_reload "$INTERFACE"
 EOF
 ```
 

--- a/pbr/README.md
+++ b/pbr/README.md
@@ -921,7 +921,7 @@ mkdir -p /etc/hotplug.d/iface/
 cat << 'EOF' > /etc/hotplug.d/iface/70-pbr
 !/bin/sh
 logger -t pbr "Reloading $INTERFACE due to $ACTION of $INTERFACE ($DEVICE)"
-/etc/init.d/pbr reload_interface "$INTERFACE"
+/etc/init.d/pbr reload interface "$INTERFACE"
 EOF
 ```
 


### PR DESCRIPTION
/etc/init.d/pbr reload_interface "$INTERFACE" is incorrect for pbr 1.1.8. There should not be an underscore in the reload_interface command

I am not able to test previous versions of pbr